### PR TITLE
Add real-time processing for FRCRN_SE_16K

### DIFF
--- a/clearvoice/config/inference/FRCRN_SE_16K.yaml
+++ b/clearvoice/config/inference/FRCRN_SE_16K.yaml
@@ -15,6 +15,6 @@ decode_window: 1 #one-pass decoding length
 #
 # FFT parameters
 win_type: 'hanning'
-win_len: 640
-win_inc: 320
+win_len: 320
+win_inc: 160
 fft_len: 640

--- a/clearvoice/demo.py
+++ b/clearvoice/demo.py
@@ -65,3 +65,17 @@ if False:
 
     #2nd calling method: process video files listed in .scp file, and write outputs to 'path_to_output_videos_tse_scp/'
     myClearVoice(input_path='samples/scp/video_samples.scp', online_write=True, output_path='samples/path_to_output_videos_tse_scp')
+
+##-----Demo Six: use FRCRN_SE_16K model for real-time processing -----------------
+if False:
+    myClearVoice = ClearVoice(task='speech_enhancement', model_names=['FRCRN_SE_16K'])
+
+    ##1st calling method: process an input waveform in real-time and return output waveform, then write to output_FRCRN_SE_16K_realtime.wav
+    output_wav = myClearVoice(input_path='samples/input_realtime.wav', online_write=False)
+    myClearVoice.write(output_wav, output_path='samples/output_FRCRN_SE_16K_realtime.wav')
+
+    ##2nd calling method: process all wav files in 'path_to_input_wavs_realtime/' in real-time and write outputs to 'path_to_output_wavs_realtime'
+    myClearVoice(input_path='samples/path_to_input_wavs_realtime', online_write=True, output_path='samples/path_to_output_wavs_realtime')
+
+    ##3rd calling method: process wav files listed in .scp file in real-time, and write outputs to 'path_to_output_wavs_realtime_scp/'
+    myClearVoice(input_path='samples/scp/audio_samples_realtime.scp', online_write=True, output_path='samples/path_to_output_wavs_realtime_scp')

--- a/clearvoice/demo_with_more_comments.py
+++ b/clearvoice/demo_with_more_comments.py
@@ -57,3 +57,31 @@ if __name__ == '__main__':
         # - online_write (bool): Set to True to enable saving the enhanced output during processing
         # - output_path (str): Path to the directory to save the enhanced output files
         myClearVoice(input_path='samples/scp/audio_samples.scp', online_write=True, output_path='samples/path_to_output_wavs_scp')
+
+    ## ---------------- Demo Three: Real-Time Processing -----------------------
+    if False:  # This block demonstrates how to use the FRCRN_SE_16K model for real-time speech enhancement
+        # Initialize ClearVoice for the task of speech enhancement using the FRCRN_SE_16K model
+        myClearVoice = ClearVoice(task='speech_enhancement', model_names=['FRCRN_SE_16K'])
+
+        # 1st calling method: 
+        #   Process an input waveform in real-time and return the enhanced output waveform
+        # - input_path (str): Path to the input noisy audio file (input_realtime.wav)
+        # - output_wav (dict or ndarray) : The enhanced output waveform
+        output_wav = myClearVoice(input_path='samples/input_realtime.wav', online_write=False)
+        # Write the processed waveform to an output file
+        # - output_path (str): Path to save the enhanced audio file (output_FRCRN_SE_16K_realtime.wav)
+        myClearVoice.write(output_wav, output_path='samples/output_FRCRN_SE_16K_realtime.wav')
+
+        # 2nd calling method: 
+        #   Process and write audio files directly in real-time
+        # - input_path (str): Path to the directory of input noisy audio files
+        # - online_write (bool): Set to True to enable saving the enhanced audio directly to files during processing
+        # - output_path (str): Path to the directory to save the enhanced output files
+        myClearVoice(input_path='samples/path_to_input_wavs_realtime', online_write=True, output_path='samples/path_to_output_wavs_realtime')
+
+        # 3rd calling method: 
+        #   Use an .scp file to specify input audio paths for real-time processing
+        # - input_path (str): Path to a .scp file listing multiple audio file paths
+        # - online_write (bool): Set to True to enable saving the enhanced audio directly to files during processing
+        # - output_path (str): Path to the directory to save the enhanced output files
+        myClearVoice(input_path='samples/scp/audio_samples_realtime.scp', online_write=True, output_path='samples/path_to_output_wavs_realtime_scp')


### PR DESCRIPTION
Related to #23

Add real-time processing support for the FRCRN_SE_16K model.

* **clearvoice/models/frcrn_se/frcrn.py**
  - Add a new method `real_time_process` to the `FRCRN_SE_16K` class for real-time processing.
  - Modify the `forward` method to support both offline and real-time processing.
  - Update the `DCCRN` class to handle real-time processing.

* **clearvoice/config/inference/FRCRN_SE_16K.yaml**
  - Change `win_len` to 320 to use 20 ms input windows.
  - Change `win_inc` to 160 to use 20 ms input windows.

* **clearvoice/demo.py**
  - Add a new demo case for real-time processing using the `FRCRN_SE_16K` model.

* **clearvoice/demo_with_more_comments.py**
  - Add a new demo case for real-time processing using the `FRCRN_SE_16K` model.

