### PR TITLE
Fix problematic down sampling for inferencing non-mono audio

### DIFF
--- a/clearvoice/dataloader/dataloader.py
+++ b/clearvoice/dataloader/dataloader.py
@@ -38,7 +38,7 @@ def audioread(path, sampling_rate):
     # Normalize the audio data.
     data, scalar = audio_norm(data)
     
-    # Convert to mono by selecting the first channel if the audio has multiple channels.
+    # Convert to mono by using librosa.to_mono if the audio has multiple channels.
     if len(data.shape) > 1:
         data = librosa.to_mono(data.T)
     

--- a/clearvoice/dataloader/dataloader.py
+++ b/clearvoice/dataloader/dataloader.py
@@ -38,13 +38,13 @@ def audioread(path, sampling_rate):
     # Normalize the audio data.
     data, scalar = audio_norm(data)
     
+    # Convert to mono by selecting the first channel if the audio has multiple channels.
+    if len(data.shape) > 1:
+        data = librosa.to_mono(data.T)
+    
     # Resample the audio if the sample rate is different from the target sampling rate.
     if fs != sampling_rate:
         data = librosa.resample(data, orig_sr=fs, target_sr=sampling_rate)
-    
-    # Convert to mono by selecting the first channel if the audio has multiple channels.
-    if len(data.shape) > 1:
-        data = data[:, 0]
     
     # Return the processed audio data.
     return data, scalar


### PR DESCRIPTION

## Problem statement
In file ClearerVoice-Studio/clearvoice/dataloader/dataloader.py:
The `librosa.resample` function expected a mono `y` input in the shape of `(frames,)`, but the input audio data is in the shape of `(frames, channels)`.

## Examples

Due to GitHub's limitation, wav files were manually converted to mp4 via ffmpeg.

Input:
https://github.com/user-attachments/assets/7a91254c-6b70-455c-bc5d-abb6323de649

Output:
https://github.com/user-attachments/assets/fce956b7-883e-42af-9ff2-f8ebe1cad1a5

Output after fix:
https://github.com/user-attachments/assets/110330dd-e7ba-47ef-8878-c3fe9ccb3f5b


## Fix
Move the "convert to mono" operation before the resampling operation. Furthermore, the `librosa.to_mono` is used to better handle the non-mono audio data.

## Result

After fixing, the code looks like this:

1. Load audio data in the shape of `(frames, channels)` and normalize the audio data.
2. Convert the audio data to mono in shape of `(frames,)` and then resample the audio data.

```python
data, fs = sf.read(path)
# output data: (frames, channels), e.g., (277830, 2)

data, scalar = audio_norm(data)
# data: (frames, channels), e.g., (277830, 2)

if len(data.shape) > 1:
    # expected data for librosa.to_mono: (channels, frames), e.g., (2, 277830)
    data = librosa.to_mono(data.T)
    # output data: (frames,), e.g., (277830,)

if fs != sampling_rate:
    # expected data: (frames,), e.g., (277830,)
    data = librosa.resample(data, orig_sr=fs, target_sr=sampling_rate)

return data, scalar
```

