### PR TITLE
fix(pyproject): update project.license format to comply with PEP 621

### DIFF
--- a/clearvoice/pyproject.toml
+++ b/clearvoice/pyproject.toml
@@ -14,11 +14,9 @@ authors = [
   { name = "Pan Zexu", email = "zexu.pan@alibaba-inc.com" },
   { name = "Nguyen Trung Hieu", email = "trunghieu.nguyen@alibaba-inc.com" },
 ]
+license = { text = "Apache-2.0" }
 readme = "README.md"
 requires-python = ">=3.8"
-
-[project.license]
-text = "Apache-2.0"
 
 dependencies = [
   "einops",

--- a/clearvoice/pyproject.toml
+++ b/clearvoice/pyproject.toml
@@ -14,9 +14,11 @@ authors = [
   { name = "Pan Zexu", email = "zexu.pan@alibaba-inc.com" },
   { name = "Nguyen Trung Hieu", email = "trunghieu.nguyen@alibaba-inc.com" },
 ]
-license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.8"
+
+[project.license]
+text = "Apache-2.0"
 
 dependencies = [
   "einops",


### PR DESCRIPTION
The license field was previously set as a bare string:
  license = "Apache-2.0"
 
This format is not valid under PEP 621, which requires `license` to be a table with either:
- { text = "Apache-2.0" }, or
- { file = "LICENSE" }
 
Updated `pyproject.toml` to use the `text` format to specify the Apache 2.0 license. This resolves build errors during editable installation.