### PR TITLE
fix RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:1 and cuda:0!

### DIFF
--- a/clearvoice/clearvoice/networks.py
+++ b/clearvoice/clearvoice/networks.py
@@ -63,7 +63,7 @@ class SpeechModel:
             if free_gpu_id is not None:
                 args.use_cuda = 1
                 torch.cuda.set_device(free_gpu_id)
-                self.device = torch.device('cuda')
+                self.device = torch.device(f'cuda:{free_gpu_id}')
             else:
                 # If no GPU is detected, use the CPU
                 #print("No GPU found. Using CPU.")


### PR DESCRIPTION
按照官网的步骤安装  测试环境 ubuntu 22.04   GPU 4*4090 运行demo 报错； python demo.py
  Running MossFormer2_SE_48K ...
    0%|                                                                                                                                                                                                                                 | 0/1 [00:00<?,
   ?it/s]
  Traceback (most recent call last):
    File "demo.py", line 25, in <module>
      output_wav = myClearVoice_SE(input_path='samples/input.wav', online_write=False)
    File "/home/user/dw/ClearerVoice-Studio/clearvoice/clearvoice/__init__.py", line 46, in __call__
      return self.call_io_mode(input_path=input_path, online_write=online_write, output_path=output_path)
    File "/home/user/dw/ClearerVoice-Studio/clearvoice/clearvoice/__init__.py", line 62, in call_io_mode
      result = model.process(input_path, online_write, output_path)
    File "/home/user/dw/ClearerVoice-Studio/clearvoice/clearvoice/networks.py", line 290, in process
      output_audios = self.decode()
    File "/home/user/dw/ClearerVoice-Studio/clearvoice/clearvoice/networks.py", line 199, in decode
      output_audio = decode_one_audio(self.model, self.device, self.data['audio'][i], self.args)
    File "/home/user/dw/ClearerVoice-Studio/clearvoice/clearvoice/utils/decode.py", line 41, in decode_one_audio
      return decode_one_audio_mossformer2_se_48k(model, device, inputs, args)
    File "/home/user/dw/ClearerVoice-Studio/clearvoice/clearvoice/utils/decode.py", line 429, in decode_one_audio_mossformer2_se_48k
      Out_List = model(fbanks)
    File "/home/user/miniconda3/envs/ClearerVoice-Studio/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
      return self._call_impl(*args, **kwargs)
    File "/home/user/miniconda3/envs/ClearerVoice-Studio/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
      return forward_call(*args, **kwargs)
    File "/home/user/dw/ClearerVoice-Studio/clearvoice/clearvoice/models/mossformer2_se/mossformer2_se_wrapper.py", line 95, in forward
      mask = self.mossformer(x)  # Forward pass through the MossFormer_MaskNet
    File "/home/user/miniconda3/envs/ClearerVoice-Studio/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
      return self._call_impl(*args, **kwargs)
    File "/home/user/miniconda3/envs/ClearerVoice-Studio/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
      return forward_call(*args, **kwargs)
    File "/home/user/dw/ClearerVoice-Studio/clearvoice/clearvoice/models/mossformer2_se/mossformer2.py", line 608, in forward
      x = self.norm(x)
    File "/home/user/miniconda3/envs/ClearerVoice-Studio/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
      return self._call_impl(*args, **kwargs)
    File "/home/user/miniconda3/envs/ClearerVoice-Studio/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
      return forward_call(*args, **kwargs)
    File "/home/user/miniconda3/envs/ClearerVoice-Studio/lib/python3.8/site-packages/torch/nn/modules/normalization.py", line 288, in forward
      return F.group_norm(
    File "/home/user/miniconda3/envs/ClearerVoice-Studio/lib/python3.8/site-packages/torch/nn/functional.py", line 2606, in group_norm
      return torch.group_norm(input, num_groups, weight, bias, eps, torch.backends.cudnn.enabled)
  RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:1 and cuda:0! (when checking argument for argument weight in method wrapper_CUDA__native_group_norm) 