### PR TITLE
Fix soxr package environment dependency bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ torchaudio>=2.0.2
 yamlargparse==1.31.1
 torchinfo==1.8.0
 tqdm==4.67.0
+soxr==0.5.0.post1
 pyyaml
 pysptk
 pymcd


### PR DESCRIPTION
The repository did not specify the version of the soxr package in the past. ClearerVoice was last updated before August 2025, while the soxr package released version 1.0 in September 2025. Installing it directly would result in installation errors and compilation of soxr would fail. Soxr is a dependency of multiple packages in the requirements.txt. Here, soxr is specified as the last version before version 1.0, 0.5.0.post1